### PR TITLE
Add packaging metadata + CI and publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test:
+    name: test (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package + test deps
+        run: |
+          python -m pip install --upgrade pip
+          # pulls najaeda>=0.7.8 (the in-engine intent link) and mcp from PyPI
+          pip install -e . pytest
+
+      - name: Run tests
+        # The CVA6 regressions self-skip without eval/.cache (a slow snapshot
+        # absent on CI); the fast structural + intent + snapshot suite runs.
+        run: pytest -q

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,75 @@
+name: Publish
+
+# Pure-Python publish pipeline, modeled on naja's wheels.yml but without the
+# cibuildwheel matrix (naja-scope ships a single py3-none-any wheel):
+#   - build sdist + wheel once and twine-check them
+#   - on push to main / manual run: upload to TestPyPI (skip-existing)
+#   - on a v* tag: upload the release to PyPI
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build
+        run: |
+          python -m pip install --upgrade build twine
+          python -m build
+          python -m twine check dist/*
+
+      - uses: actions/upload-artifact@v8
+        with:
+          name: dist
+          path: dist/*
+
+  test-pypi:
+    name: Upload to TestPyPI
+    needs: build
+    if: github.repository == 'najaeda/naja-scope' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # enables trusted publishing if a TestPyPI publisher is configured
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1.14.0
+        with:
+          # Drop `password:` and configure a PyPI "trusted publisher" (OIDC) to
+          # publish without a long-lived token — recommended. Token works too.
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  pypi:
+    name: Upload release to PyPI
+    needs: test-pypi
+    if: github.repository == 'najaeda/naja-scope' && github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1.14.0
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 __pycache__/
 *.pyc
 *.egg-info/
+dist/
+build/
 .pytest_cache/
 .DS_Store
 naja_perf.log

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ See [DESIGN.md](DESIGN.md) for architecture and scope;
 [NAJAEDA_NOTES.md](NAJAEDA_NOTES.md) for upstream feature requests and bugs
 found while building phase 1.
 
-## Status: phase 1 (structural spine + source ranges) + phase-2 intent prototype
+## Status: phase 1 (structural spine + source ranges) + phase-2 intent layer
 
-Phase 1 is the core; the phase-2 living-intent layer (`get_intent`, warm-only,
-opt-in) shipped as a prototype after passing its eval gate (scope+intent ≤ grep
-turns on cva6-small; see `docs/phase2-plan.md` §4). The DESIGN.md §3 workflow
-works end to end:
+Phase 1 is the core; the phase-2 living-intent layer (`get_intent`, warm-only) is
+productized — a thin, pyslang-free client over naja's in-engine SNL↔slang link
+(`keep_ast_link`, shipped in najaeda 0.7.8). Its eval gate passed and was
+re-confirmed on the productized layer (scope+intent ≤ grep turns on cva6-small;
+see `docs/phase2-plan.md` §4). The DESIGN.md §3 workflow works end to end:
 
 ```
 resolve("uart_top.u_tx.tx_o")   → term descriptor with src range
@@ -29,15 +30,21 @@ Three calls, well under a thousand tokens, answer plus quotable source.
 ## Install / run
 
 ```sh
-python3.11 -m venv --system-site-packages .venv   # najaeda from site-packages
-.venv/bin/pip install -e .
-.venv/bin/naja-scope-mcp                          # stdio MCP server
+pip install naja-scope        # pulls najaeda>=0.7.8 and mcp from PyPI
+naja-scope-mcp                # stdio MCP server
 ```
 
 Register with Claude Code:
 
 ```sh
-claude mcp add naja-scope -- /path/to/naja-scope/.venv/bin/naja-scope-mcp
+claude mcp add naja-scope -- naja-scope-mcp
+```
+
+For development from a checkout, install editable instead:
+
+```sh
+python3.11 -m venv .venv
+.venv/bin/pip install -e .
 ```
 
 ## Tools
@@ -59,19 +66,19 @@ Source & summaries: `get_source` (the SV lines that produced an object),
 `get_module_card` (deterministic ports/counts/clock-reset card),
 `get_stats` (per-model rollups).
 
-Intent (phase-2 prototype): `get_intent` — source-level facts the netlist
-*erases in lowering*: enum/typedef state names + encodings (incl. **package**
-typedefs whose members live in another file) and **symbolic parameter
-expressions** (the formula behind a baked-in width). Backed by a separate
-`pyslang` re-elaboration kept alive beside the SNL session, so it is **warm-only**
-(a slang `Compilation` never serializes): enable it with `load_intent`,
-`load_systemverilog(intent=true)` / `load_snapshot(intent=true)`, or the
-`NAJA_SCOPE_INTENT=1` env opt-in; `status` reports `intent_loaded` /
-`intent_loadable`. Cold sessions degrade gracefully ("intent layer not loaded;
-source range available via get_source"). Needs the optional dep:
-`pip install 'naja-scope[intent]'`. (This is route 1 of DESIGN.md "Phase 2" — the
-prototype that passed the eval gate; the exact in-engine link is P2.2, see
-`docs/phase2-plan.md`.)
+Intent (phase 2): `get_intent` — source-level facts the netlist *erases in
+lowering*: enum/typedef state names + encodings (incl. **package** typedefs whose
+members live in another file), **packed struct/union** fields, and **symbolic
+parameter expressions** (the formula behind a baked-in width). Backed by naja's
+in-engine SNL↔slang link (`keep_ast_link`, najaeda 0.7.8) — a thin, pyslang-free
+client that calls `naja.intent_*` and returns plain dicts; **no second
+elaboration**. It is **warm-only** (a slang `Compilation` never serializes):
+enable it with `load_intent`, `load_systemverilog(intent=true)` /
+`load_snapshot(intent=true)`, or the `NAJA_SCOPE_INTENT=1` env opt-in; `status`
+reports `intent_loaded` / `intent_loadable`. Cold sessions degrade gracefully
+("intent layer not loaded; source range available via get_source") and re-bind by
+re-elaborating from the snapshot-persisted load spec. No extra Python dependency
+(see DESIGN.md "Phase 2" + `docs/phase2-plan.md`).
 
 Escape hatch: `query_python` — najaeda is the query language; recurring
 patterns observed there get promoted to first-class tools.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,12 +7,32 @@ name = "naja-scope"
 version = "0.1.0"
 description = "Agent-facing MCP query layer over najaeda: navigate elaborated SystemVerilog designs without loading source into context."
 readme = "README.md"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
+authors = [
+    { name = "naja authors", email = "contact@keplertech.io" },
+]
+keywords = ["mcp", "systemverilog", "eda", "netlist", "rtl", "najaeda", "llm", "agent"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
+    "Topic :: Software Development :: Libraries",
+]
 dependencies = [
     "najaeda>=0.7.8",
     "mcp>=1.2",
 ]
+
+[project.urls]
+Homepage = "https://github.com/najaeda/naja-scope"
+Repository = "https://github.com/najaeda/naja-scope"
+Issues = "https://github.com/najaeda/naja-scope/issues"
 
 # Phase-2 living-intent layer (get_intent) needs NO extra Python dependency: it
 # is a thin client over naja's in-engine SNL↔slang link (naja.intent_*), which


### PR DESCRIPTION
Prepare naja-scope for PyPI distribution:
- LICENSE (Apache-2.0) + PEP 639 license metadata, authors, keywords, classifiers, and project URLs in pyproject.toml.
- README install section now leads with `pip install naja-scope`; intent description updated to the productized pyslang-free in-engine link.
- CI workflow: pytest on py3.10-3.13 against the PyPI najaeda 0.7.8 wheel (CVA6 regressions self-skip without the eval cache).
- Publish workflow modeled on naja's wheels.yml without the cibuildwheel matrix (pure-Python single wheel): build + twine check, TestPyPI on push/dispatch, PyPI on v* tag.
- gitignore dist/ and build/.