### PR TITLE
Release 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "naja-scope"
-version = "0.1.1"
+version = "0.1.2"
 description = "Agent-facing MCP query layer over najaeda: navigate elaborated SystemVerilog designs without loading source into context."
 readme = "README_PyPI.md"
 license = "Apache-2.0"


### PR DESCRIPTION
PyPI 0.1.1 was built from a stale tag (v0.1.1 points at the old "prepare new version" commit, predating the public-release cleanup, gate-level support, examples packaging, and README rewrite). A PyPI version cannot be reused, so cut 0.1.2 from main's HEAD, which contains all of that work. Bump version to 0.1.2 so the v0.1.2 tag publishes the correct artifact.